### PR TITLE
Fix: BePartialViewResult().Model throws NullReferenceException

### DIFF
--- a/src/FluentAssertions.Mvc3/ViewResultBaseAssertions.cs
+++ b/src/FluentAssertions.Mvc3/ViewResultBaseAssertions.cs
@@ -111,7 +111,7 @@ namespace FluentAssertions.Mvc
         {
             get
             {
-                var model = (Subject as ViewResult).Model;
+                var model = (Subject as ViewResultBase).Model;
                 return model;
             }
         }

--- a/tests/FluentAssertions.Mvc3.Tests/ViewResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.Mvc3.Tests/ViewResultAssertions_Tests.cs
@@ -187,7 +187,7 @@ namespace FluentAssertions.Mvc.Tests
         }
 
         [Test]
-        public void Model_GivenExpectedValue_ShouldPass()
+        public void Model_ForViewResult_GivenExpectedValue_ShouldPass()
         {
             ActionResult result = new ViewResult
             {
@@ -198,7 +198,18 @@ namespace FluentAssertions.Mvc.Tests
         }
 
         [Test]
-        public void Model_GivenUnexpectedValue_ShouldFail()
+        public void Model_ForPartialViewResult_GivenExpectedValue_ShouldPass()
+        {
+            ActionResult result = new PartialViewResult
+            {
+                ViewData = new ViewDataDictionary("hello")
+            };
+
+            result.Should().BePartialViewResult().Model.Should().Be("hello");
+        }
+
+        [Test]
+        public void Model_ForViewResult_GivenUnexpectedValue_ShouldFail()
         {
             ActionResult result = new ViewResult
             {
@@ -210,7 +221,19 @@ namespace FluentAssertions.Mvc.Tests
         }
 
         [Test]
-        public void ModelAs_GivenExpectedValue_ShouldPass()
+        public void Model_ForPartialViewResult_GivenUnexpectedValue_ShouldFail()
+        {
+            ActionResult result = new PartialViewResult
+            {
+                ViewData = new ViewDataDictionary("hello")
+            };
+
+            Action a = () => result.Should().BePartialViewResult().Model.Should().Be("xyx");
+            a.ShouldThrow<Exception>();
+        }
+
+        [Test]
+        public void ModelAs_ForViewResult_GivenExpectedValue_ShouldPass()
         {
             ActionResult result = new ViewResult
             {
@@ -221,7 +244,18 @@ namespace FluentAssertions.Mvc.Tests
         }
 
         [Test]
-        public void ModelAs_GivenUnexpectedValue_ShouldFail()
+        public void ModelAs_ForPartialViewResult_GivenExpectedValue_ShouldPass()
+        {
+            ActionResult result = new PartialViewResult
+            {
+                ViewData = new ViewDataDictionary("hello")
+            };
+
+            result.Should().BePartialViewResult().ModelAs<string>().Should().Be("hello");
+        }
+
+        [Test]
+        public void ModelAs_ForViewResult_GivenUnexpectedValue_ShouldFail()
         {
             ActionResult result = new ViewResult
             {
@@ -233,7 +267,19 @@ namespace FluentAssertions.Mvc.Tests
         }
 
         [Test]
-        public void ModelAs_GivenWrongType_ShouldFail()
+        public void ModelAs_ForPartialViewResult_GivenUnexpectedValue_ShouldFail()
+        {
+            ActionResult result = new PartialViewResult
+            {
+                ViewData = new ViewDataDictionary("hello")
+            };
+
+            Action a = () => result.Should().BePartialViewResult().ModelAs<string>().Should().Be("xyx");
+            a.ShouldThrow<Exception>();
+        }
+
+        [Test]
+        public void ModelAs_ForViewResult_GivenWrongType_ShouldFail()
         {
             ActionResult result = new ViewResult
             {
@@ -245,12 +291,36 @@ namespace FluentAssertions.Mvc.Tests
         }
 
         [Test]
-        public void ModelAs_Null_ShouldFail()
+        public void ModelAs_ForPartialViewResult_GivenWrongType_ShouldFail()
+        {
+            ActionResult result = new PartialViewResult
+            {
+                ViewData = new ViewDataDictionary("hello")
+            };
+
+            Action a = () => result.Should().BePartialViewResult().ModelAs<int>().Should().Be(2);
+            a.ShouldThrow<Exception>();
+        }
+
+        [Test]
+        public void ModelAs_ForViewResult_Null_ShouldFail()
         {
             ActionResult result = new ViewResult();
             string failureMessage = FailureMessageHelper.Format(FailureMessages.ViewResultBase_NullModel, typeof(Object).Name);
 
             Action a = () => result.Should().BeViewResult().ModelAs<Object>();
+            
+            a.ShouldThrow<Exception>()
+                    .WithMessage(failureMessage);
+        }
+
+        [Test]
+        public void ModelAs_ForPartialViewResult_Null_ShouldFail()
+        {
+            ActionResult result = new PartialViewResult();
+            string failureMessage = FailureMessageHelper.Format(FailureMessages.ViewResultBase_NullModel, typeof(Object).Name);
+
+            Action a = () => result.Should().BePartialViewResult().ModelAs<Object>();
             
             a.ShouldThrow<Exception>()
                     .WithMessage(failureMessage);


### PR DESCRIPTION
In ViewResultBaseAssertions.Model, the subject was being cast to
ViewResult.  This caused a NullReferenceException when the subject was a
PartialViewResult.  If the subject is cast to ViewResultBase instead, the
exception is avoided.
